### PR TITLE
Make asmble great again

### DIFF
--- a/enginerunner/Dockerfile
+++ b/enginerunner/Dockerfile
@@ -118,18 +118,6 @@ COPY node-timer.js ./node/node-timer.js
 
 
 # install java
-# ENV JAVA_VER 8
-# ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-
-# RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
-#     echo 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
-#     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
-#     apt-get update && \
-#     echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
-#     apt-get install -y --force-yes --no-install-recommends oracle-java${JAVA_VER}-installer oracle-java${JAVA_VER}-set-default && \
-#     apt-get clean && \
-#     rm -rf /var/cache/oracle-jdk${JAVA_VER}-installer
-#RUN apt-get update && apt-get install -y --force-yes --no-install-recommends default-jre openjdk-8-jre-headless
 RUN apt-get update && apt-get install -y --force-yes --no-install-recommends openjdk-8-jdk
 
 # install asmble

--- a/enginerunner/Dockerfile
+++ b/enginerunner/Dockerfile
@@ -118,17 +118,19 @@ COPY node-timer.js ./node/node-timer.js
 
 
 # install java
-ENV JAVA_VER 8
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+# ENV JAVA_VER 8
+# ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
-RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
-    echo 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
-    apt-get update && \
-    echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
-    apt-get install -y --force-yes --no-install-recommends oracle-java${JAVA_VER}-installer oracle-java${JAVA_VER}-set-default && \
-    apt-get clean && \
-    rm -rf /var/cache/oracle-jdk${JAVA_VER}-installer
+# RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
+#     echo 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
+#     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
+#     apt-get update && \
+#     echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
+#     apt-get install -y --force-yes --no-install-recommends oracle-java${JAVA_VER}-installer oracle-java${JAVA_VER}-set-default && \
+#     apt-get clean && \
+#     rm -rf /var/cache/oracle-jdk${JAVA_VER}-installer
+#RUN apt-get update && apt-get install -y --force-yes --no-install-recommends default-jre openjdk-8-jre-headless
+RUN apt-get update && apt-get install -y --force-yes --no-install-recommends openjdk-8-jdk
 
 # install asmble
 RUN wget https://github.com/cdetrio/asmble/releases/download/0.4.2-fl-bench-times/asmble-0.4.2-fl-bench-times.tar

--- a/enginerunner/project/settings.py
+++ b/enginerunner/project/settings.py
@@ -52,7 +52,8 @@ vm_descriptors = {
 
     "wasmi"  : VMDescriptor("/engines/wasmi/target/release/examples/invoke", "{wasm_file_path} {function_name}"),
 
-    "asmble" : VMDescriptor("/engines/asmble/bin/asmble", "invoke -in {wasm_file_path} {function_name} -defmaxmempages 20000")
+    "asmble" : VMDescriptor("/engines/asmble/bin/asmble", "invoke -in {wasm_file_path} {function_name}")
+    #"asmble" : VMDescriptor("/engines/asmble/bin/asmble", "invoke -in {wasm_file_path} {function_name} -defmaxmempages 20000")
 
     # "wasmer" : VMDescriptor("/engines/wasmer/target/release/wasmer", "run {wasm_file_path}", True),
     # we have binaryen, but calling wasm-shell -e main is not working

--- a/enginerunner/project/settings.py
+++ b/enginerunner/project/settings.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from project.VMDescriptor import VMDescriptor
-from project.TestDescriptor import TestDescriptor
-from os.path import join
 
 # export function name that should be called from each Wasm module
 test_export_function_name = "main"
@@ -53,7 +51,6 @@ vm_descriptors = {
     "wasmi"  : VMDescriptor("/engines/wasmi/target/release/examples/invoke", "{wasm_file_path} {function_name}"),
 
     "asmble" : VMDescriptor("/engines/asmble/bin/asmble", "invoke -in {wasm_file_path} {function_name}")
-    #"asmble" : VMDescriptor("/engines/asmble/bin/asmble", "invoke -in {wasm_file_path} {function_name} -defmaxmempages 20000")
 
     # "wasmer" : VMDescriptor("/engines/wasmer/target/release/wasmer", "run {wasm_file_path}", True),
     # we have binaryen, but calling wasm-shell -e main is not working


### PR DESCRIPTION
- enginerunner:
  - Replace oracle with openJDK
  - Remove -defmaxmempage arg which was causing out of memory error
  - Remove a few unused imports in settings.py
- evmrace:
  - manually install newer version of cmake