### PR TITLE
update readme, scripts were renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ $ docker run -it --entrypoint=/bin/bash -v $(pwd)/evmwasmfiles:/evmwasmfiles -v 
 
 ### run geth native precompile benchmarks
 ## parse results and save to /evmraceresults/geth_precompile_benchmarks.csv
-$ PYTHONIOENCODING=UTF-8 python3 precompileracer.py
+$ PYTHONIOENCODING=UTF-8 python3 benchgethprecompiles.py
 
+
+### run parity native precompile benchmarks
+## parse results and save to /evmraceresults/parity_precompile_benchmarks.csv
+$ PYTHONIOENCODING=UTF-8 python3 benchparityprecompiles.py
 
 $ PYTHONIOENCODING=UTF-8 python3 evmracer.py
 


### PR DESCRIPTION
I was running the benchmarks an noticed the scripts mentioned in the README has been renamed, I have updated the README.

I suppose `benchevm.py` corresponds to `evmracer.py`, but I was confused because the README mentions this "after running evmracer.py, standalone wasm files will be saved to /evmwasmfiles" , and `benchevm.py` doesn't work on that directory AFAIK.